### PR TITLE
Pinned posts

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -140,6 +140,8 @@ paths:
     $ref: 'write/posts/pid/vote.yaml'
   /posts/{pid}/bookmark:
     $ref: 'write/posts/pid/bookmark.yaml'
+  /posts/{pid}/pin:
+    $ref: 'write/posts/pid/pin.yaml'
   /posts/{pid}/diffs:
     $ref: 'write/posts/pid/diffs.yaml'
   /posts/{pid}/diffs/{since}:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -52,6 +52,8 @@ get:
                     type: number
                   bookmarks:
                     type: number
+                  pinned:
+                    type: number
                   votes:
                     type: number
                   timestampISO:

--- a/public/openapi/write/posts/pid/pin.yaml
+++ b/public/openapi/write/posts/pid/pin.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - posts
+  summary: pin a post
+  description: This operation pins a post.
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post successfully pinned
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - posts
+  summary: unpin a post
+  description: This operation unpins a post.
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post successfully unpinned
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -225,17 +225,10 @@ define('forum/topic/events', [
     }
 
     function togglePostPinned(data) {
-        const el = $('[data-pid="' + data.post.pid + '"] [component="post/pin"]').filter(function (_, el) {
-            return parseInt($(el).closest('[data-pid]').attr('data-pid'), 10) === parseInt(data.post.pid, 10);
-        });
-        if (!el.length) {
-            return;
+        // Just redirect the user back to the top of the topic
+         if (data) {
+            ajaxify.go('topic/' + data.post.tid, null, true);
         }
-
-        el.attr('data-pinned', data.pinned);
-
-        el.find('[component="post/pin/on"]').toggleClass('hidden', !data.pinned);
-        el.find('[component="post/pin/off"]').toggleClass('hidden', data.pinned);
     }
 
     function togglePostVote(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -40,6 +40,11 @@ define('forum/topic/events', [
         'posts.bookmark': togglePostBookmark,
         'posts.unbookmark': togglePostBookmark,
 
+        /*
+            Since this change does not depend on the signature of this
+            function at all, I will just assert type information in the
+            function itself for now -- tkroenin
+        */
         'posts.pin': togglePostPinned,
         'posts.unpin': togglePostPinned,
 
@@ -225,10 +230,30 @@ define('forum/topic/events', [
     }
 
     function togglePostPinned(data) {
+        /*
+            Parameters:
+            Takes in a parameter `data`. For the purposes of this function, we
+            only care that it contains a field corresponding to information
+            about an individual post, and that this field tracks the post's
+            tid (an int).
+
+            Returns:
+            Nothing - this is a hook that redirects the user to the 'top' of
+            the topic.
+        */
+
+        /* I think this style of assertion is the best you can do in front-end
+           code */
+        console.assert(data.hasOwnProperty('post'), 'Data has no post property');
+        console.assert(data.post.hasOwnProperty('tid'), 'Post field has not tid property');
+        console.assert(typeof (data.post.tid) === typeof (1), `Expected type 'number' for 'tid' field, but got ${typeof (data.post.tid)}`);
+
         // Just redirect the user back to the top of the topic
         if (data) {
             ajaxify.go('topic/' + data.post.tid, null, true);
         }
+
+        // Nothing to assert for the return
     }
 
     function togglePostVote(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -226,7 +226,7 @@ define('forum/topic/events', [
 
     function togglePostPinned(data) {
         // Just redirect the user back to the top of the topic
-         if (data) {
+        if (data) {
             ajaxify.go('topic/' + data.post.tid, null, true);
         }
     }

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -40,6 +40,9 @@ define('forum/topic/events', [
         'posts.bookmark': togglePostBookmark,
         'posts.unbookmark': togglePostBookmark,
 
+        'posts.pin': togglePostPinned,
+        'posts.unpin': togglePostPinned,
+
         'posts.upvote': togglePostVote,
         'posts.downvote': togglePostVote,
         'posts.unvote': togglePostVote,
@@ -219,6 +222,20 @@ define('forum/topic/events', [
 
         el.find('[component="post/bookmark/on"]').toggleClass('hidden', !data.isBookmarked);
         el.find('[component="post/bookmark/off"]').toggleClass('hidden', data.isBookmarked);
+    }
+
+    function togglePostPinned(data) {
+        const el = $('[data-pid="' + data.post.pid + '"] [component="post/pin"]').filter(function (_, el) {
+            return parseInt($(el).closest('[data-pid]').attr('data-pid'), 10) === parseInt(data.post.pid, 10);
+        });
+        if (!el.length) {
+            return;
+        }
+
+        el.attr('data-pinned', data.pinned);
+
+        el.find('[component="post/pin/on"]').toggleClass('hidden', !data.pinned);
+        el.find('[component="post/pin/off"]').toggleClass('hidden', data.pinned);
     }
 
     function togglePostVote(data) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -116,6 +116,10 @@ define('forum/topic/postTools', [
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
+        postContainer.on('click', '[component="post/pin"]', function () {
+            return pinPost($(this), getData($(this), 'data-pid'));
+        });
+
         postContainer.on('click', '[component="post/upvote"]', function () {
             return votes.toggleVote($(this), '.upvoted', 1);
         });
@@ -362,6 +366,21 @@ define('forum/topic/postTools', [
             hooks.fire(`action:post.${type}`, { pid: pid });
         });
         return false;
+    }
+
+    function pinPost(button, pid) {
+        const method = button.attr('data-pinned') === 'false' ? 'put' : 'del';
+
+        // Make an API call as above to get the post pinned...
+         api[method](`/posts/${pid}/pin`, undefined, function (err) {
+            if (err) {
+                return alerts.error(err);
+            }
+            const type = method === 'put' ? 'pin' : 'unpin';
+            hooks.fire(`action:post.${type}`, { pid: pid });
+        });
+        return false;
+
     }
 
     function getData(button, data) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -372,7 +372,7 @@ define('forum/topic/postTools', [
         const method = button.attr('data-pinned') === 'false' ? 'put' : 'del';
 
         // Make an API call as above to get the post pinned...
-         api[method](`/posts/${pid}/pin`, undefined, function (err) {
+        api[method](`/posts/${pid}/pin`, undefined, function (err) {
             if (err) {
                 return alerts.error(err);
             }
@@ -380,7 +380,6 @@ define('forum/topic/postTools', [
             hooks.fire(`action:post.${type}`, { pid: pid });
         });
         return false;
-
     }
 
     function getData(button, data) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -117,6 +117,20 @@ define('forum/topic/postTools', [
         });
 
         postContainer.on('click', '[component="post/pin"]', function () {
+            /*
+            This is an event handler - and so doesn't have any
+            interesting parameters or return types
+
+            What's important is that element actually has a data-pid attribute.
+            */
+            console.assert(this.hasAttribute('data-pinned'), "Element didn't have data-pinned property!");
+            const attributeValue = this.getAttribute('data-pinned');
+            console.assert(attributeValue === 'true' || attributeValue === 'false', 'data-pinned is not true');
+
+            const dataPid = getData($(this), 'data-pid');
+            console.assert(!(isNaN(dataPid)), 'Invalid data-pid.');
+            // End of tests
+
             return pinPost($(this), getData($(this), 'data-pid'));
         });
 
@@ -369,6 +383,17 @@ define('forum/topic/postTools', [
     }
 
     function pinPost(button, pid) {
+        /*
+            Parameters: an HTML element representing the button we pressed,
+            and a pid of the post we're interacting with.
+
+            Returns: error or false if something goes wrong. Returns nothing
+            if everything goes well, but fires a hook.
+        */
+
+        // We only really care about checking that the pid is a number
+        console.assert(!(isNaN(pid)), 'pid argument to pinPost is not a valid number');
+
         const method = button.attr('data-pinned') === 'false' ? 'put' : 'del';
 
         // Make an API call as above to get the post pinned...

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -273,6 +273,14 @@ postsAPI.unbookmark = async function (caller, data) {
     return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
 };
 
+postsAPI.pin = async function (caller, data) {
+    return await apiHelpers.postCommand(caller, 'pin', 'pinned', '', data);
+};
+
+postsAPI.unpin = async function (caller, data) {
+    return await apiHelpers.postCommand(caller, 'unpin', 'unpinned', '', data);
+};
+
 async function diffsPrivilegeCheck(pid, uid) {
     const [deleted, privilegesData] = await Promise.all([
         posts.getPostField(pid, 'deleted'),

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// For JS requirement
+const assert = require('assert');
+
 const nconf = require('nconf');
 const qs = require('querystring');
 
@@ -124,6 +127,10 @@ topicsController.get = async function getTopic(req, res, next) {
         rel.href = `${url}/topic/${topicData.slug}${rel.href}`;
         res.locals.linkTags.push(rel);
     });
+
+    // Ensure that pinned posts are added as a list to the result in some form
+    assert(topicData.hasOwnProperty('pinnedPosts'), 'topicData does not have a pinned posts field');
+    assert(typeof (topicData.pinnedPosts) === typeof ([]));
 
     res.render('topic', topicData);
 };

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -80,6 +80,11 @@ topicsController.get = async function getTopic(req, res, next) {
 
     await topics.getTopicWithPosts(topicData, set, req.uid, start, stop, reverse);
 
+    if (currentPage !== 1) {
+        // Pinned posts should only appear on the first page.
+        topicData.pinnedPosts = [];
+    }
+
     topics.modifyPostsByPrivilege(topicData, userPrivileges);
     topicData.tagWhitelist = categories.filterTagWhitelist(topicData.tagWhitelist, userPrivileges.isAdminOrMod);
 

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// For JS requirement
+const assert = require('assert');
+
 const posts = require('../../posts');
 const privileges = require('../../privileges');
 
@@ -84,13 +87,41 @@ Posts.unbookmark = async (req, res) => {
 };
 
 Posts.pin = async (req, res) => {
+    /*
+        Parameters: a request object with information about the post to pin,
+        and a response object to write the response to
+
+        Returns: nothing, but writes into res.
+    */
+
     const data = await mock(req);
+
+    /*
+        Test that request has the needed fields
+    */
+    assert(data.hasOwnProperty('pid'), 'Pin request has no pid field');
+    assert(!(isNaN(data.pid)));
+
     await api.posts.pin(req, data);
     helpers.formatApiResponse(200, res);
 };
 
 Posts.unpin = async (req, res) => {
+    /*
+        Parameters: a request object with information about the post to unpin,
+        and a response object to write the response to
+
+        Returns: nothing, but writes into res.
+    */
+
     const data = await mock(req);
+
+    /*
+        Test that request has the needed fields
+    */
+    assert(data.hasOwnProperty('pid'), 'Unpin request has no pid field');
+    assert(!(isNaN(data.pid)));
+
     await api.posts.unpin(req, data);
     helpers.formatApiResponse(200, res);
 };

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -87,13 +87,13 @@ Posts.pin = async (req, res) => {
     const data = await mock(req);
     await api.posts.pin(req, data);
     helpers.formatApiResponse(200, res);
-}
+};
 
 Posts.unpin = async (req, res) => {
     const data = await mock(req);
     await api.posts.unpin(req, data);
     helpers.formatApiResponse(200, res);
-}
+};
 
 Posts.getDiffs = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -83,6 +83,18 @@ Posts.unbookmark = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
+Posts.pin = async (req, res) => {
+    const data = await mock(req);
+    await api.posts.pin(req, data);
+    helpers.formatApiResponse(200, res);
+}
+
+Posts.unpin = async (req, res) => {
+    const data = await mock(req);
+    await api.posts.unpin(req, data);
+    helpers.formatApiResponse(200, res);
+}
+
 Posts.getDiffs = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
-    'replies', 'bookmarks',
+    'replies', 'bookmarks', 'pinned',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -23,6 +23,7 @@ require('./recent')(Posts);
 require('./tools')(Posts);
 require('./votes')(Posts);
 require('./bookmarks')(Posts);
+require('./pin')(Posts);
 require('./queue')(Posts);
 require('./diffs')(Posts);
 require('./uploads')(Posts);

--- a/src/posts/pin.js
+++ b/src/posts/pin.js
@@ -1,64 +1,68 @@
+"use strict";
 /* All of the below is directly taken and modified from src/posts/bookmarks.js
 
-This needs to be translated to TypeScript, eventually.
+For the TS translation, I referenced azhang49's translation from P1:
+https://github.com/CMU-313/NodeBB/pull/73
 */
-
-'use strict';
-
-const plugins = require('../plugins');
-
-module.exports = function (Posts) {
-    Posts.pin = async function (pid, uid) {
-        return await togglePin('pin', pid, uid);
-    };
-
-    Posts.unpin = async function (pid, uid) {
-        return await togglePin('unpin', pid, uid);
-    };
-
-    async function togglePin(type, pid, uid) {
-        if (parseInt(uid, 10) <= 0) {
-            throw new Error('[[error:not-logged-in]]');
-        }
-
-        const isPinning = type === 'pin';
-
-        const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
-
-        const hasPinned = await Posts.hasPinned(pid, uid);
-
-        if (isPinning && hasPinned) {
-            throw new Error('Already pinned!');
-        }
-
-        if (!isPinning && !hasPinned) {
-            throw new Error('Already unpinned!');
-        }
-
-        // TODO: This line is sketchy.
-        const toWrite = isPinning ? 1 : 0;
-        await Posts.setPostField(pid, 'pinned', toWrite);
-
-        plugins.hooks.fire(`action:post.${type}`, {
-            pid: pid,
-            tid: postData.tid,
-            uid: uid,
-            owner: postData.uid,
-            current: hasPinned ? 'pinned' : 'unpinned',
-        });
-
-        return {
-            post: postData,
-            pinned: isPinning,
-        };
-    }
-
-    Posts.hasPinned = async function (pid, uid) {
-        if (parseInt(uid, 10) <= 0) {
-            return Array.isArray(pid) ? pid.map(() => false) : false;
-        }
-
-        const postData = await Posts.getPostFields(pid, ['pinned']);
-        return Boolean(postData.pinned);
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
+const plugins = require("../plugins");
+function postFunc(Posts) {
+    function togglePin(type, pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (parseInt(uid, 10) <= 0) {
+                throw new Error('[[error:not-logged-in]]');
+            }
+            const isPinning = type === 'pin';
+            const postData = yield Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
+            const hasPinned = yield Posts.hasPinned(pid, uid);
+            if (isPinning && hasPinned) {
+                throw new Error('Already pinned!');
+            }
+            if (!isPinning && !hasPinned) {
+                throw new Error('Already unpinned!');
+            }
+            // TODO: This line is sketchy.
+            const toWrite = isPinning ? 1 : 0;
+            yield Posts.setPostField(pid, 'pinned', toWrite);
+            yield plugins.hooks.fire(`action:post.${type}`, {
+                pid: pid,
+                tid: postData.tid,
+                uid: uid,
+                owner: postData.uid,
+                current: hasPinned ? 'pinned' : 'unpinned',
+            });
+            return {
+                post: postData,
+                pinned: isPinning,
+            };
+        });
+    }
+    Posts.hasPinned = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (parseInt(uid, 10) <= 0) {
+                return Array.isArray(pid) ? pid.map(() => false) : false;
+            }
+            const postData = yield Posts.getPostFields(pid, ['pinned']);
+            return Boolean(postData.pinned);
+        });
+    };
+    Posts.pin = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield togglePin('pin', pid, uid);
+        });
+    };
+    Posts.unpin = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield togglePin('unpin', pid, uid);
+        });
+    };
+}
+module.exports = postFunc;

--- a/src/posts/pin.js
+++ b/src/posts/pin.js
@@ -14,6 +14,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 const plugins = require("../plugins");
+const topics = require("../topics");
 function postFunc(Posts) {
     function togglePin(type, pid, uid) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -62,6 +63,18 @@ function postFunc(Posts) {
     Posts.unpin = function (pid, uid) {
         return __awaiter(this, void 0, void 0, function* () {
             return yield togglePin('unpin', pid, uid);
+        });
+    };
+    Posts.isTopicOP = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (parseInt(uid, 10) <= 0 || parseInt(pid, 10) <= 0) {
+                return false;
+            }
+            // Get the post's topic
+            const postData = yield Posts.getPostFields(pid, ['tid']);
+            // Get the topic itself
+            const topicData = yield topics.getTopicFields(postData.tid, ['uid']);
+            return uid === topicData.uid;
         });
     };
 }

--- a/src/posts/pin.js
+++ b/src/posts/pin.js
@@ -1,0 +1,65 @@
+/* All of the below is directly taken and modified from src/posts/bookmarks.js
+
+This needs to be translated to TypeScript, eventually.
+*/
+'use strict';
+
+const db = require('../database');
+const plugins = require('../plugins');
+
+module.exports = function (Posts) {
+    Posts.pin = async function (pid, uid) {
+        return await togglePin('pin', pid, uid);
+    };
+
+    Posts.unpin = async function (pid, uid) {
+        return await togglePin('unpin', pid, uid);
+    };
+
+    async function togglePin(type, pid, uid) {
+        if (parseInt(uid, 10) <= 0) {
+            throw new Error('[[error:not-logged-in]]');
+        }
+
+        const isPinning = type === 'pin';
+
+        const postData = await Posts.getPostFields(pid, ['pid', 'uid']);
+
+        let hasPinned = await Posts.hasPinned(pid, uid);
+
+        if (isPinning && hasPinned) {
+            throw new Error("Already pinned!");
+        }
+
+        if (!isPinning && !hasPinned) {
+            throw new Error("Already unpinned!");
+        }
+
+        // TODO: This line is sketchy.
+        let toWrite = isPinning ? 1 : 0;
+        await Posts.setPostField(pid, 'pinned', toWrite);
+
+        let pinned = await Posts.hasPinned(pid, uid);
+
+        plugins.hooks.fire(`action:post.${type}`, {
+            pid: pid,
+            uid: uid,
+            owner: postData.uid,
+            current: hasPinned ? 'pinned' : 'unpinned',
+        });
+
+        return {
+            post: postData,
+            pinned: isPinning,
+        };
+    }
+
+    Posts.hasPinned = async function (pid, uid) {
+        if (parseInt(uid, 10) <= 0) {
+            return Array.isArray(pid) ? pid.map(() => false) : false;
+        }
+
+        let postData = await Posts.getPostFields(pid, ['pinned']);
+        return Boolean(postData.pinned);
+    };
+};

--- a/src/posts/pin.js
+++ b/src/posts/pin.js
@@ -23,7 +23,7 @@ module.exports = function (Posts) {
 
         const isPinning = type === 'pin';
 
-        const postData = await Posts.getPostFields(pid, ['pid', 'uid']);
+        const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
 
         let hasPinned = await Posts.hasPinned(pid, uid);
 
@@ -39,10 +39,9 @@ module.exports = function (Posts) {
         let toWrite = isPinning ? 1 : 0;
         await Posts.setPostField(pid, 'pinned', toWrite);
 
-        let pinned = await Posts.hasPinned(pid, uid);
-
         plugins.hooks.fire(`action:post.${type}`, {
             pid: pid,
+            tid: postData.tid,
             uid: uid,
             owner: postData.uid,
             current: hasPinned ? 'pinned' : 'unpinned',

--- a/src/posts/pin.js
+++ b/src/posts/pin.js
@@ -2,9 +2,9 @@
 
 This needs to be translated to TypeScript, eventually.
 */
+
 'use strict';
 
-const db = require('../database');
 const plugins = require('../plugins');
 
 module.exports = function (Posts) {
@@ -25,18 +25,18 @@ module.exports = function (Posts) {
 
         const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
 
-        let hasPinned = await Posts.hasPinned(pid, uid);
+        const hasPinned = await Posts.hasPinned(pid, uid);
 
         if (isPinning && hasPinned) {
-            throw new Error("Already pinned!");
+            throw new Error('Already pinned!');
         }
 
         if (!isPinning && !hasPinned) {
-            throw new Error("Already unpinned!");
+            throw new Error('Already unpinned!');
         }
 
         // TODO: This line is sketchy.
-        let toWrite = isPinning ? 1 : 0;
+        const toWrite = isPinning ? 1 : 0;
         await Posts.setPostField(pid, 'pinned', toWrite);
 
         plugins.hooks.fire(`action:post.${type}`, {
@@ -58,7 +58,7 @@ module.exports = function (Posts) {
             return Array.isArray(pid) ? pid.map(() => false) : false;
         }
 
-        let postData = await Posts.getPostFields(pid, ['pinned']);
+        const postData = await Posts.getPostFields(pid, ['pinned']);
         return Boolean(postData.pinned);
     };
 };

--- a/src/posts/pin.ts
+++ b/src/posts/pin.ts
@@ -1,0 +1,81 @@
+/* All of the below is directly taken and modified from src/posts/bookmarks.js
+
+For the TS translation, I referenced azhang49's translation from P1:
+https://github.com/CMU-313/NodeBB/pull/73
+*/
+
+import plugins = require('../plugins');
+
+type PostData = {
+    tid : string;
+    uid : string;
+    pinned : number;
+}
+
+type Post = {
+    pin : (pid : string, uid : string) => Promise<unknown>;
+    unpin : (pid : string, uid : string) => Promise<unknown>;
+    hasPinned : (pid : string, uid : string) => Promise<boolean | boolean[]>;
+    getPostFields : (pid : string, fields : string[]) => Promise<PostData>;
+    setPostField : (pid : string, field : string, value : number) => Promise<unknown>;
+}
+
+function postFunc(Posts : Post) {
+    async function togglePin(type : string, pid : string, uid : string) {
+        if (parseInt(uid, 10) <= 0) {
+            throw new Error('[[error:not-logged-in]]');
+        }
+
+        const isPinning = type === 'pin';
+
+        const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
+
+        const hasPinned = await Posts.hasPinned(pid, uid);
+
+        if (isPinning && hasPinned) {
+            throw new Error('Already pinned!');
+        }
+
+        if (!isPinning && !hasPinned) {
+            throw new Error('Already unpinned!');
+        }
+
+        // TODO: This line is sketchy.
+        const toWrite = isPinning ? 1 : 0;
+        await Posts.setPostField(pid, 'pinned', toWrite);
+
+        await plugins.hooks.fire(`action:post.${type}`, {
+            pid: pid,
+            tid: postData.tid,
+            uid: uid,
+            owner: postData.uid,
+            current: hasPinned ? 'pinned' : 'unpinned',
+        });
+
+        return {
+            post: postData,
+            pinned: isPinning,
+        };
+    }
+
+    Posts.hasPinned = async function (pid, uid) {
+        if (parseInt(uid, 10) <= 0) {
+            return Array.isArray(pid) ? pid.map(() => false) : false;
+        }
+
+        const postData = await Posts.getPostFields(pid, ['pinned']);
+        return Boolean(postData.pinned);
+    };
+
+
+    Posts.pin = async function (pid : string, uid : string) {
+        return await togglePin('pin', pid, uid);
+    };
+
+    Posts.unpin = async function (pid : string, uid : string) {
+        return await togglePin('unpin', pid, uid);
+    };
+}
+
+
+export = postFunc;

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -26,6 +26,10 @@ module.exports = function () {
     setupApiRoute(router, 'put', '/:pid/bookmark', [...middlewares, middleware.assert.post], controllers.write.posts.bookmark);
     setupApiRoute(router, 'delete', '/:pid/bookmark', [...middlewares, middleware.assert.post], controllers.write.posts.unbookmark);
 
+    // New pinning feature
+    setupApiRoute(router, 'put', '/:pid/pin', [...middlewares, middleware.assert.post], controllers.write.posts.pin);
+    setupApiRoute(router, 'delete', '/:pid/pin', [...middlewares, middleware.assert.post], controllers.write.posts.unpin);
+
     setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
     setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
     setupApiRoute(router, 'put', '/:pid/diffs/:since', [...middlewares, middleware.assert.post], controllers.write.posts.restoreDiff);

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -33,12 +33,15 @@ module.exports = function (SocketPosts) {
             postSharing: social.getActivePostSharing(),
             history: posts.diffs.exists(data.pid),
             canViewInfo: privileges.global.can('view:users:info', socket.uid),
+            // Is the user also the topic owner?
+            isTopicOP: posts.isTopicOP(data.pid, socket.uid),
         });
 
         const postData = results.posts;
         postData.absolute_url = `${nconf.get('url')}/post/${data.pid}`;
         postData.bookmarked = results.bookmarked;
         postData.selfPost = socket.uid && socket.uid === postData.uid;
+        postData.displayPin = results.isTopicOP || results.isAdmin || results.isGlobalMod || results.isModerator;
         postData.display_edit_tools = results.canEdit.flag;
         postData.display_delete_tools = results.canDelete.flag;
         postData.display_purge_tools = results.canPurge;

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -29,6 +29,7 @@ module.exports = function (SocketPosts) {
             canFlag: privileges.posts.canFlag(data.pid, socket.uid),
             flagged: flags.exists('post', data.pid, socket.uid), // specifically, whether THIS calling user flagged
             bookmarked: posts.hasBookmarked(data.pid, socket.uid),
+            pinned: posts.hasPinned(data.pid, socket.uid),
             postSharing: social.getActivePostSharing(),
             history: posts.diffs.exists(data.pid),
             canViewInfo: privileges.global.can('view:users:info', socket.uid),

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -156,6 +156,7 @@ Topics.getTopicsByTids = async function (tids, options) {
 Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, reverse) {
     const [
         posts,
+        pinnedPosts,
         category,
         tagWhitelist,
         threadTools,
@@ -169,6 +170,7 @@ Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, rev
         events,
     ] = await Promise.all([
         Topics.getTopicPosts(topicData, set, start, stop, uid, reverse),
+        Topics.getTopicPinnedPosts(topicData, uid),
         categories.getCategoryData(topicData.cid),
         categories.getTagWhitelist([topicData.cid]),
         plugins.hooks.fire('filter:topic.thread_tools', { topic: topicData, uid: uid, tools: [] }),
@@ -212,6 +214,8 @@ Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, rev
     topicData.related = related || [];
     topicData.unreplied = topicData.postcount === 1;
     topicData.icons = [];
+
+    topicData.pinnedPosts = pinnedPosts;
 
     const result = await plugins.hooks.fire('filter:topic.get', { topic: topicData, uid: uid });
     return result.topic;

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -20,22 +20,20 @@ module.exports = function (Topics) {
         await Topics.addPostToTopic(postData.tid, postData);
     };
 
-    Topics.getTopicPinnedPosts = async function(topicData, uid) {
+    Topics.getTopicPinnedPosts = async function (topicData, uid) {
         // Let's just get *all* the posts belonging to this `tid`
-        let allPids = await db.getSortedSetMembers(`tid:${topicData.tid}:posts`);
+        const allPids = await db.getSortedSetMembers(`tid:${topicData.tid}:posts`);
 
         // Then filter by pinned
-        let postData = await posts.getPostsByPids(allPids, uid);
+        const postData = await posts.getPostsByPids(allPids, uid);
         let pinnedPosts = postData.filter(
-            (postObject) => {
-                return postObject.pinned;
-            }
+            postObject => postObject.pinned
         );
 
         pinnedPosts = Topics.addPostData(pinnedPosts, uid);
 
         return pinnedPosts;
-    }
+    };
 
     Topics.getTopicPosts = async function (topicData, set, start, stop, uid, reverse) {
         if (!topicData) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -1,6 +1,9 @@
 
 'use strict';
 
+// JS requirement
+const assert = require('assert');
+
 const _ = require('lodash');
 const validator = require('validator');
 const nconf = require('nconf');
@@ -21,6 +24,19 @@ module.exports = function (Topics) {
     };
 
     Topics.getTopicPinnedPosts = async function (topicData, uid) {
+        /*
+            Parameters:
+                - `topicData`: an object with information about the topic
+                - `uid`: the user id
+
+            Returns: a list of post objects, all of which are pinned
+        */
+
+        assert(topicData.hasOwnProperty('tid'), 'topicData has no tid field!');
+        assert(typeof topicData.tid === typeof 1);
+        assert(topicData.hasOwnProperty('uid'), 'topicData has no uid field!');
+        assert(typeof topicData.uid === typeof 1);
+
         // Let's just get *all* the posts belonging to this `tid`
         const allPids = await db.getSortedSetMembers(`tid:${topicData.tid}:posts`);
 
@@ -30,7 +46,20 @@ module.exports = function (Topics) {
             postObject => postObject.pinned
         );
 
-        pinnedPosts = Topics.addPostData(pinnedPosts, uid);
+        pinnedPosts = await Topics.addPostData(pinnedPosts, uid);
+
+        function hasCorrectFields(postData) {
+            return (
+                postData.hasOwnProperty('pid') &&
+                (typeof postData.pid === typeof 1) &&
+                postData.hasOwnProperty('tid') &&
+                (typeof postData.tid === typeof 1) &&
+                postData.hasOwnProperty('pinned') &&
+                (typeof postData.pinned === typeof 1)
+            );
+        }
+
+        assert(pinnedPosts.every(hasCorrectFields));
 
         return pinnedPosts;
     };

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -195,9 +195,11 @@ module.exports = function (Topics) {
             modifyPost(post);
         });
 
-        topicData.pinnedPosts.forEach((post) => {
-            modifyPost(post);
-        });
+        if (topicData.hasOwnProperty('pinnedPosts')) {
+            topicData.pinnedPosts.forEach((post) => {
+                modifyPost(post);
+            });
+        }
     };
 
     Topics.addParentPosts = async function (postData) {

--- a/src/views/partials/data/pinnedPost.tpl
+++ b/src/views/partials/data/pinnedPost.tpl
@@ -1,0 +1,1 @@
+data-index="{pinnedPosts.index}" data-pid="{pinnedPosts.pid}" data-uid="{pinnedPosts.uid}" data-timestamp="{pinnedPosts.timestamp}" data-username="{pinnedPosts.user.username}" data-userslug="{pinnedPosts.user.userslug}" itemscope itemtype="http://schema.org/Comment"

--- a/test/posts.js
+++ b/test/posts.js
@@ -395,8 +395,7 @@ describe('Post\'s', () => {
 
         // (4)
         it('random user cannot see the pin button', (done) => {
-            // Deliberate mistake - 'globalModUid'
-            socketPosts.loadPostTools({ uid: globalModUid }, { pid: postData.pid, cid: cid }, (err, data) => {
+            socketPosts.loadPostTools({ uid: randomUserUid }, { pid: postData.pid, cid: cid }, (err, data) => {
                 assert.ifError(err);
                 assert(!(data.posts.displayPin));
                 done();

--- a/themes/nodebb-theme-persona/templates/partials/topic/pinned-post-menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/pinned-post-menu.tpl
@@ -1,0 +1,4 @@
+<span component="post/tools" class="dropdown moderator-tools bottom-sheet <!-- IF !pinnedPosts.display_post_menu -->hidden<!-- ENDIF !pinnedPosts.display_post_menu -->">
+    <a href="#" data-toggle="dropdown" data-ajaxify="false"><i class="fa fa-fw fa-ellipsis-v"></i></a>
+    <ul class="dropdown-menu dropdown-menu-right hidden" role="menu"></ul>
+</span>

--- a/themes/nodebb-theme-persona/templates/partials/topic/pinnedBadge.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/pinnedBadge.tpl
@@ -1,0 +1,5 @@
+{{{each pinnedPosts.user.selectedGroups}}}
+<!-- IF pinnedPosts.user.selectedGroups.slug -->
+<a href="{config.relative_path}/groups/{pinnedPosts.user.selectedGroups.slug}"><small class="label group-label inline-block" style="color:{pinnedPosts.user.selectedGroups.textColor};background-color: {pinnedPosts.user.selectedGroups.labelColor};"><!-- IF pinnedPosts.user.selectedGroups.icon --><i class="fa {pinnedPosts.user.selectedGroups.icon}"></i> <!-- ENDIF pinnedPosts.user.selectedGroups.icon -->{pinnedPosts.user.selectedGroups.userTitle}</small></a>
+<!-- ENDIF pinnedPosts.user.selectedGroups.slug -->
+{{{end}}}

--- a/themes/nodebb-theme-persona/templates/partials/topic/pinnedPost.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/pinnedPost.tpl
@@ -1,0 +1,110 @@
+<div class="clearfix post-header">
+    <div class="icon pull-left">
+        <a href="<!-- IF pinnedPosts.user.userslug -->{config.relative_path}/user/{pinnedPosts.user.userslug}<!-- ELSE -->#<!-- ENDIF pinnedPosts.user.userslug -->">
+            {buildAvatar(pinnedPosts.user, "sm2x", true, "", "user/picture")}
+            <i component="user/status" class="fa fa-circle status {pinnedPosts.user.status}" title="[[global:{pinnedPosts.user.status}]]"></i>
+        </a>
+    </div>
+
+    <small class="pull-left">
+        <strong>
+            <a href="<!-- IF pinnedPosts.user.userslug -->{config.relative_path}/user/{pinnedPosts.user.userslug}<!-- ELSE -->#<!-- ENDIF pinnedPosts.user.userslug -->" itemprop="author" data-username="{pinnedPosts.user.username}" data-uid="{pinnedPosts.user.uid}">{pinnedPosts.user.displayname}</a>
+        </strong>
+
+        <!-- IMPORT partials/topic/pinnedBadge.tpl -->
+
+        <!-- IF pinnedPosts.user.banned -->
+        <span class="label label-danger">[[user:banned]]</span>
+        <!-- ENDIF pinnedPosts.user.banned -->
+
+        <span class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block">
+            <!-- IF pinnedPosts.toPid -->
+            <a component="post/parent" class="btn btn-xs btn-default hidden-xs" data-topid="{pinnedPosts.toPid}" href="{config.relative_path}/post/{pinnedPosts.toPid}"><i class="fa fa-reply"></i> @<!-- IF pinnedPosts.parent.username -->{pinnedPosts.parent.username}<!-- ELSE -->[[global:guest]]<!-- ENDIF pinnedPosts.parent.username --></a>
+            <!-- ENDIF pinnedPosts.toPid -->
+
+            <span>
+                <!-- IF pinnedPosts.user.custom_profile_info.length -->
+                &#124;
+                {{{each pinnedPosts.user.custom_profile_info}}}
+                {pinnedPosts.user.custom_profile_info.content}
+                {{{end}}}
+                <!-- ENDIF pinnedPosts.user.custom_profile_info.length -->
+            </span>
+        </span>
+
+    </small>
+    <small class="pull-right">
+        <span class="bookmarked"><i class="fa fa-bookmark-o"></i></span>
+    </small>
+    <small class="pull-right">
+        <i component="post/edit-indicator" class="fa fa-pencil-square<!-- IF privileges.pinnedPosts:history --> pointer<!-- END --> edit-icon <!-- IF !pinnedPosts.editor.username -->hidden<!-- ENDIF !pinnedPosts.editor.username -->"></i>
+
+        <small data-editor="{pinnedPosts.editor.userslug}" component="post/editor" class="hidden">[[global:last_edited_by, {pinnedPosts.editor.username}]] <span class="timeago" title="{pinnedPosts.editedISO}"></span></small>
+
+        {{{ if pinnedPosts.pinned }}}
+            <span class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"><i class="fa fa-thumbtack" style="color: red;"></i> Pinned &nbsp;</span>
+        {{{ end }}}
+
+        <span class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block">
+            <a class="permalink" href="{config.relative_path}/post/{pinnedPosts.pid}"><span class="timeago" title="{pinnedPosts.timestampISO}"></span></a>
+        </span>
+    </small>
+</div>
+
+<br />
+
+<div class="content" component="post/content" itemprop="text">
+    {pinnedPosts.content}
+</div>
+
+<div class="post-footer">
+    {{{ if pinnedPosts.user.signature }}}
+    <div component="post/signature" data-uid="{pinnedPosts.user.uid}" class="post-signature">{pinnedPosts.user.signature}</div>
+    {{{ end }}}
+
+    <div class="clearfix">
+    {{{ if !hideReplies }}}
+    <a component="post/reply-count" data-target-component="post/replies/container" href="#" class="threaded-replies no-select pull-left {{{ if !pinnedPosts.replies.count }}}hidden{{{ end }}}">
+        <span component="post/reply-count/avatars" class="avatars {{{ if pinnedPosts.replies.hasMore }}}hasMore{{{ end }}}">
+            {{{each pinnedPosts.replies.users}}}
+            {buildAvatar(pinnedPosts.replies.users, "xs", true, "")}
+            {{{end}}}
+        </span>
+
+        <span class="replies-count" component="post/reply-count/text" data-replies="{pinnedPosts.replies.count}">{pinnedPosts.replies.text}</span>
+        <span class="replies-last hidden-xs">[[topic:last_reply_time]] <span class="timeago" title="{pinnedPosts.replies.timestampISO}"></span></span>
+
+        <i class="fa fa-fw fa-chevron-right" component="post/replies/open"></i>
+        <i class="fa fa-fw fa-chevron-down hidden" component="post/replies/close"></i>
+        <i class="fa fa-fw fa-spin fa-spinner hidden" component="post/replies/loading"></i>
+    </a>
+    {{{ end }}}
+
+    <small class="pull-right">
+        <!-- IMPORT partials/topic/reactions.tpl -->
+        <span class="post-tools">
+            <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
+            <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
+        </span>
+
+        <!-- IF !reputation:disabled -->
+        <span class="votes">
+            <a component="post/upvote" href="#" class="<!-- IF pinnedPosts.upvoted -->upvoted<!-- ENDIF pinnedPosts.upvoted -->">
+                <i class="fa fa-chevron-up"></i>
+            </a>
+
+            <span component="post/vote-count" data-votes="{pinnedPosts.votes}">{pinnedPosts.votes}</span>
+
+            <!-- IF !downvote:disabled -->
+            <a component="post/downvote" href="#" class="<!-- IF pinnedPosts.downvoted -->downvoted<!-- ENDIF pinnedPosts.downvoted -->">
+                <i class="fa fa-chevron-down"></i>
+            </a>
+            <!-- ENDIF !downvote:disabled -->
+        </span>
+        <!-- ENDIF !reputation:disabled -->
+
+        <!-- IMPORT partials/topic/pinned-post-menu.tpl -->
+    </small>
+    </div>
+    <div component="post/replies/container"></div>
+</div>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -100,6 +100,14 @@
             <a role="menuitem" component="share/{postSharing.id}" tabindex="-1" href="#"><span class="menu-icon"><i class="fa fa-fw {postSharing.class}"></i></span> {postSharing.name}</a>
         </li>
     {{{end}}}
+
+    <!-- New "Pinned Post" Feature -->
+    <li>
+        <a component="post/pin" data-pinned="{pinned}" role="menuitem" tabindex="-1" href=""><i class="fa fa-fw fa-thumb-tack"></i>
+        <span component="post/pin/off" class="<!-- IF pinned --> hidden <!-- ENDIF pinned -->">Pin post</span>
+        <span component="post/pin/on"  class="<!-- IF !pinned -->hidden <!-- ENDIF !pinned -->">Unpin post</span>
+        </a>
+    </li>
 <!-- ENDIF !posts.deleted -->
 
 {{{ if posts.display_flag_tools }}}

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -101,6 +101,7 @@
         </li>
     {{{end}}}
 
+    {{{ if posts.displayPin }}}
     <!-- New "Pinned Post" Feature -->
     <li>
         <a component="post/pin" data-pinned="{pinned}" role="menuitem" tabindex="-1" href=""><i class="fa fa-fw fa-thumb-tack"></i>
@@ -108,6 +109,7 @@
         <span component="post/pin/on"  class="<!-- IF !pinned -->hidden <!-- ENDIF !pinned -->">Unpin post</span>
         </a>
     </li>
+    {{{ end }}}
 <!-- ENDIF !posts.deleted -->
 
 {{{ if posts.display_flag_tools }}}

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -41,6 +41,10 @@
 
         <small data-editor="{posts.editor.userslug}" component="post/editor" class="hidden">[[global:last_edited_by, {posts.editor.username}]] <span class="timeago" title="{posts.editedISO}"></span></small>
 
+        {{{ if posts.pinned }}}
+            <span class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"><i class="fa fa-thumbtack" style="color: red;"></i> Pinned &nbsp;</span>
+        {{{ end }}}
+
         <span class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block">
             <a class="permalink" href="{config.relative_path}/post/{posts.pid}"><span class="timeago" title="{posts.timestampISO}"></span></a>
         </span>

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -62,16 +62,49 @@
         {{{ end }}}
 
         <ul component="topic" class="posts timeline" data-tid="{tid}" data-cid="{cid}">
+            <!-- Display topic starter and pinned posts first -->
+            
+            <!-- Topic starter -->
             {{{each posts}}}
-                <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
-                    <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
+                {{{ if (posts.index == 0) }}}
+                    <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+                        <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
 
-                    <meta itemprop="datePublished" content="{posts.timestampISO}">
-                    <meta itemprop="dateModified" content="{posts.editedISO}">
+                        <meta itemprop="datePublished" content="{posts.timestampISO}">
+                        <meta itemprop="dateModified" content="{posts.editedISO}">
 
-                    <!-- IMPORT partials/topic/post.tpl -->
-                </li>
-                {renderTopicEvents(@index, config.topicPostSort)}
+                        <!-- IMPORT partials/topic/post.tpl -->
+                    </li>
+                    {renderTopicEvents(@index, config.topicPostSort)}
+                {{{ end }}}
+            {{{end}}}
+
+            <!-- Pinned posts -->
+            {{{each pinnedPosts}}}
+                {{{ if pinnedPosts.pinned }}}
+                    <li component="post" class="{{{ if pinnedPosts.deleted }}}deleted{{{ end }}} {{{ if pinnedPosts.selfPost }}}self-post{{{ end }}} {{{ if pinnedPosts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/pinnedPost.tpl -->>
+                        <a component="post/anchor" data-index="{pinnedPosts.index}" id="{pinnedPosts.index}"></a>
+
+                        <meta itemprop="datePublished" content="{pinnedPosts.timestampISO}">
+                        <meta itemprop="dateModified" content="{pinnedPosts.editedISO}">
+
+                        <!-- IMPORT partials/topic/pinnedPost.tpl -->
+                    </li>
+                    {renderTopicEvents(@index, config.topicPostSort)}
+                {{{ end }}}
+            {{{end}}}
+
+            <!-- Then all the other posts -->
+            {{{each posts}}}
+                    <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+                        <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
+
+                        <meta itemprop="datePublished" content="{posts.timestampISO}">
+                        <meta itemprop="dateModified" content="{posts.editedISO}">
+
+                        <!-- IMPORT partials/topic/post.tpl -->
+                    </li>
+                    {renderTopicEvents(@index, config.topicPostSort)}
             {{{end}}}
         </ul>
 


### PR DESCRIPTION
All done, including an attempt at the JS/documentation requirement.

Would resolve #1, resolve #2, resolve #4.

In particular this adds:
- Working API routes for pinning and unpinning posts. Also includes accompanying schema documentation.
- A button in the post tools UI that invokes these API calls.
- Accompanying TS translations, or type assertions for the JS requirement.
- Integration with forum permissions (only admins/mods/topic owners can see the button).
- Automated tests in `tests/posts.js` that enforce those permissions.

Also see the new documentation on how to test this feature in #29!