### PR TITLE
Removed inconsistent "endorse" keys

### DIFF
--- a/public/language/ar/topic.json
+++ b/public/language/ar/topic.json
@@ -14,7 +14,6 @@
     "quote": "اقتبس",
     "reply": "رد",
     "resolve": "Resolve",
-    "endorse": "Endorse",
 	"post_resolved": "Resolved",
     "replies_to_this_post": "%1 Replies",
     "one_reply_to_this_post": "1 Reply",

--- a/public/language/de/topic.json
+++ b/public/language/de/topic.json
@@ -14,7 +14,6 @@
     "quote": "Zitieren",
     "reply": "Antworten",
     "resolve": "Resolve",
-    "endorse": "Endorse",
 	"post_resolved": "Resolved",
     "replies_to_this_post": "%1 Antworten",
     "one_reply_to_this_post": "1 Antwort",


### PR DESCRIPTION
Removed "endorse" keys that only appear in `public/language/ar/topic.json` and `public/language/de/topic.json`.

I think this should fix our CI failures.