### PR TITLE
Filtered out duplicate topic starter post

### DIFF
--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -96,15 +96,17 @@
 
             <!-- Then all the other posts -->
             {{{each posts}}}
-                    <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
-                        <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
+                    {{{ if (posts.index != 0) }}}
+                        <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+                            <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
 
-                        <meta itemprop="datePublished" content="{posts.timestampISO}">
-                        <meta itemprop="dateModified" content="{posts.editedISO}">
+                            <meta itemprop="datePublished" content="{posts.timestampISO}">
+                            <meta itemprop="dateModified" content="{posts.editedISO}">
 
-                        <!-- IMPORT partials/topic/post.tpl -->
-                    </li>
-                    {renderTopicEvents(@index, config.topicPostSort)}
+                            <!-- IMPORT partials/topic/post.tpl -->
+                        </li>
+                        {renderTopicEvents(@index, config.topicPostSort)}
+                    {{{end}}}
             {{{end}}}
         </ul>
 


### PR DESCRIPTION
Modified `themes/nodebb-theme-persona/templates/topic.tpl` to filter out the duplicate topic starter post. This seems to resolve this issue locally.
![Screenshot_20240312_172355](https://github.com/CMU-313/spring24-nodebb-roger/assets/92952795/3ad263dd-dba6-4e06-a0c3-eb837e9719e0)

Would fix #36.