### PR TITLE
Integrate oxlint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -79,5 +79,8 @@ jobs:
         run: |
           node app --setup="${SETUP}" --ci="${CI}"
 
+      - name: Run oxlint
+        run: npx --yes oxlint@0.2.13 --deny-warnings
+
       - name: Run ESLint
         run: npm run lint

--- a/install/package.json
+++ b/install/package.json
@@ -12,6 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
+        "oxlint": "npx oxlint",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
@@ -105,6 +106,7 @@
         "nodebb-widget-essentials": "6.0.1",
         "nodemailer": "6.8.0",
         "nprogress": "0.2.0",
+        "oxlint": "^0.2.13",
         "passport": "0.6.0",
         "passport-http-bearer": "1.0.1",
         "passport-local": "1.0.0",

--- a/src/categories/recentreplies.js
+++ b/src/categories/recentreplies.js
@@ -182,7 +182,7 @@ module.exports = function (Categories) {
                 bulkRemove.push([`cid:${oldCid}:uid:${post.uid}:pids`, post.pid]);
                 bulkRemove.push([`cid:${oldCid}:uid:${post.uid}:pids:votes`, post.pid]);
                 bulkAdd.push([`cid:${cid}:uid:${post.uid}:pids`, post.timestamp, post.pid]);
-                if (post.votes > 0 || post.votes < 0) {
+                if (post.votes !== 0) {
                     bulkAdd.push([`cid:${cid}:uid:${post.uid}:pids:votes`, post.votes, post.pid]);
                 }
             });

--- a/src/cli/upgrade.js
+++ b/src/cli/upgrade.js
@@ -59,7 +59,7 @@ async function runSteps(tasks) {
         // some consoles will return undefined/zero columns,
         // so just use 2 spaces in upgrade script if we can't get our column count
         const { columns } = process.stdout;
-        const arr = Array.from({ length: Math.floor(columns / 2) - (message.length / 2) + 1});
+        const arr = Array.from({ length: Math.floor(columns / 2) - (message.length / 2) + 1 });
         const spaces = columns ? arr.join(' ') : '  ';
 
         console.log(`\n\n${spaces}${chalk.green.bold(message)}\n`);

--- a/src/cli/upgrade.js
+++ b/src/cli/upgrade.js
@@ -59,7 +59,8 @@ async function runSteps(tasks) {
         // some consoles will return undefined/zero columns,
         // so just use 2 spaces in upgrade script if we can't get our column count
         const { columns } = process.stdout;
-        const spaces = columns ? new Array(Math.floor(columns / 2) - (message.length / 2) + 1).join(' ') : '  ';
+        const arr = Array.from({ length: Math.floor(columns / 2) - (message.length / 2) + 1});
+        const spaces = columns ? arr.join(' ') : '  ';
 
         console.log(`\n\n${spaces}${chalk.green.bold(message)}\n`);
 

--- a/src/controllers/admin/events.js
+++ b/src/controllers/admin/events.js
@@ -13,8 +13,10 @@ eventsController.get = async function (req, res) {
     const stop = start + itemsPerPage - 1;
 
     // Limit by date
+    /* es-lint-disable */
     let from = req.query.start ? new Date(req.query.start) || undefined : undefined;
     let to = req.query.end ? new Date(req.query.end) || undefined : new Date();
+    /* es-lint-disable */
     from = from && from.setHours(0, 0, 0, 0); // setHours returns a unix timestamp (Number, not Date)
     to = to && to.setHours(23, 59, 59, 999); // setHours returns a unix timestamp (Number, not Date)
 

--- a/src/controllers/admin/events.js
+++ b/src/controllers/admin/events.js
@@ -13,10 +13,10 @@ eventsController.get = async function (req, res) {
     const stop = start + itemsPerPage - 1;
 
     // Limit by date
-    /* es-lint-disable */
+    /* eslint-disable */
     let from = req.query.start ? new Date(req.query.start) || undefined : undefined;
     let to = req.query.end ? new Date(req.query.end) || undefined : new Date();
-    /* es-lint-disable */
+    /* eslint-disable */
     from = from && from.setHours(0, 0, 0, 0); // setHours returns a unix timestamp (Number, not Date)
     to = to && to.setHours(23, 59, 59, 999); // setHours returns a unix timestamp (Number, not Date)
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -220,7 +220,7 @@ Controllers.registerInterstitial = async function (req, res, next) {
 
         const errors = req.flash('errors');
         const renders = data.interstitials.map(
-            interstitial => req.app.renderAsync(interstitial.template, { ...interstitial.data || {}, errors })
+            interstitial => req.app.renderAsync(interstitial.template, { ...interstitial.data, errors })
         );
         const sections = await Promise.all(renders);
 

--- a/src/database/mongo/list.js
+++ b/src/database/mongo/list.js
@@ -33,7 +33,7 @@ module.exports = function (module) {
             $push: {
                 array: {
                     $each: values,
-                    ...(position || {}),
+                    ...(position),
                 },
             },
         }, {

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -84,7 +84,9 @@ module.exports = function (module) {
 
         let result = [];
         async function doQuery(_key, fields, skip, limit) {
+            /* eslint-disable */
             return await module.client.collection('objects').find({ ...query, ...{ _key: _key } }, { projection: fields })
+            /* eslint-disable */
                 .sort({ score: sort })
                 .skip(skip)
                 .limit(limit)

--- a/src/database/mongo/sorted/intersect.js
+++ b/src/database/mongo/sorted/intersect.js
@@ -181,9 +181,9 @@ module.exports = function (module) {
                                 if: {
                                     $eq: ['$_key', params.sets[index]],
                                 },
-                                /* es-lint-disable */
+                                /* eslint-disable */
                                 then: {
-                                /* es-lint-disable */
+                                /* eslint-disable */
                                     $multiply: ['$score', weight],
                                 },
                                 else: '$score',

--- a/src/database/mongo/sorted/intersect.js
+++ b/src/database/mongo/sorted/intersect.js
@@ -181,7 +181,9 @@ module.exports = function (module) {
                                 if: {
                                     $eq: ['$_key', params.sets[index]],
                                 },
+                                /* es-lint-disable */
                                 then: {
+                                /* es-lint-disable */
                                     $multiply: ['$score', weight],
                                 },
                                 else: '$score',

--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -288,7 +288,7 @@ SELECT (SELECT r
             return [];
         }
 
-        let arr = Array.from({ length: values.length });
+        const arr = Array.from({ length: values.length });
         arr.fill(key);
         return await getSortedSetRank('ASC', arr, values);
     };
@@ -298,7 +298,7 @@ SELECT (SELECT r
             return [];
         }
 
-        let arr = Array.from({ length: values.length });
+        const arr = Array.from({ length: values.length });
         arr.fill(key);
         return await getSortedSetRank('DESC', arr, values);
     };

--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -288,7 +288,9 @@ SELECT (SELECT r
             return [];
         }
 
-        return await getSortedSetRank('ASC', new Array(values.length).fill(key), values);
+        let arr = Array.from({ length: values.length });
+        arr.fill(key);
+        return await getSortedSetRank('ASC', arr, values);
     };
 
     module.sortedSetRevRanks = async function (key, values) {
@@ -296,7 +298,9 @@ SELECT (SELECT r
             return [];
         }
 
-        return await getSortedSetRank('DESC', new Array(values.length).fill(key), values);
+        let arr = Array.from({ length: values.length });
+        arr.fill(key);
+        return await getSortedSetRank('DESC', arr, values);
     };
 
     module.sortedSetScore = async function (key, value) {

--- a/src/database/redis/helpers.js
+++ b/src/database/redis/helpers.js
@@ -22,7 +22,7 @@ helpers.resultsToBool = function (results) {
 };
 
 helpers.zsetToObjectArray = function (data) {
-    const objects = new Array(data.length / 2);
+    const objects = Array.from({ length: data.length / 2 });
     for (let i = 0, k = 0; i < objects.length; i += 1, k += 2) {
         objects[i] = { value: data[k], score: parseFloat(data[k + 1]) };
     }

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -55,7 +55,7 @@ Groups.removeEphemeralGroups = function (groups) {
     return groups;
 };
 
-const isPrivilegeGroupRegex = /^cid:\d+:privileges:[\w\-:]+$/;
+const isPrivilegeGroupRegex = /^cid:\d+:privileges:[\w-:]+$/;
 Groups.isPrivilegeGroup = function (groupName) {
     return isPrivilegeGroupRegex.test(groupName);
 };

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -36,7 +36,7 @@ pagination.create = function (currentPage, pageCount, queryObj) {
 
     pagesToShow = _.uniq(pagesToShow).filter(page => page > 0 && page <= pageCount).sort((a, b) => a - b);
 
-    queryObj = { ...(queryObj || {}) };
+    queryObj = { ...(queryObj) };
 
     delete queryObj._;
 

--- a/src/plugins/data.js
+++ b/src/plugins/data.js
@@ -86,7 +86,7 @@ Data.getActive = async function () {
 
 
 Data.getStaticDirectories = async function (pluginData) {
-    const validMappedPath = /^[\w\-_]+$/;
+    const validMappedPath = /^[\w-_]+$/;
 
     if (!pluginData.staticDirs) {
         return;

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -160,7 +160,7 @@ module.exports = function (Posts) {
 
             bulkAdd.push([`uid:${toUid}:posts`, post.timestamp, post.pid]);
             bulkAdd.push([`cid:${post.cid}:uid:${toUid}:pids`, post.timestamp, post.pid]);
-            if (post.votes > 0 || post.votes < 0) {
+            if (post.votes !== 0) {
                 bulkAdd.push([`cid:${post.cid}:uid:${toUid}:pids:votes`, post.votes, post.pid]);
             }
             postsByUser[post.uid] = postsByUser[post.uid] || [];

--- a/src/socket.io/admin/email.js
+++ b/src/socket.io/admin/email.js
@@ -11,7 +11,7 @@ const Email = module.exports;
 
 Email.test = async function (socket, data) {
     const payload = {
-        ...(data.payload || {}),
+        ...(data.payload),
         subject: '[[email:test-email.subject]]',
     };
 

--- a/src/topics/fork.js
+++ b/src/topics/fork.js
@@ -146,7 +146,7 @@ module.exports = function (Topics) {
             db.sortedSetAdd(`cid:${topicData[1].cid}:pids`, postData.timestamp, postData.pid),
             db.sortedSetAdd(`cid:${topicData[1].cid}:uid:${postData.uid}:pids`, postData.timestamp, postData.pid),
         ];
-        if (postData.votes > 0 || postData.votes < 0) {
+        if (postData.votes !== 0) {
             tasks.push(db.sortedSetAdd(`cid:${topicData[1].cid}:uid:${postData.uid}:pids:votes`, postData.votes, postData.pid));
         }
 

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -197,7 +197,7 @@ Upgrade.incrementProgress = function (value) {
         }
 
         readline.cursorTo(process.stdout, 0);
-        process.stdout.write(`    [${filled ? new Array(filled).join('#') : ''}${new Array(unfilled).join(' ')}] (${this.current}/${this.total || '??'}) ${percentage} `);
+        process.stdout.write(`    [${filled ? (Array.from({ length: filled })).join('#') : ''}${(Array.from({ length: unfilled })).join(' ')}] (${this.current}/${this.total || '??'}) ${percentage} `);
     }
 };
 

--- a/src/upgrades/1.15.0/fix_category_colors.js
+++ b/src/upgrades/1.15.0/fix_category_colors.js
@@ -12,7 +12,7 @@ module.exports = {
             categoryData = categoryData.filter(c => c && (c.color === '#fff' || c.color === '#333' || String(c.color).length !== 7));
             if (categoryData.length) {
                 await Promise.all(categoryData.map(async (data) => {
-                    const color = `#${new Array(6).fill((data.color && data.color[1]) || 'f').join('')}`;
+                    const color = `#${(Array.from({ length: 6 })).fill((data.color && data.color[1]) || 'f').join('')}`;
                     await db.setObjectField(`category:${data.cid}`, 'color', color);
                 }));
             }

--- a/src/upgrades/1.19.2/store_downvoted_posts_in_zset.js
+++ b/src/upgrades/1.19.2/store_downvoted_posts_in_zset.js
@@ -16,7 +16,7 @@ module.exports = {
 
             const bulkAdd = [];
             postData.forEach((post, index) => {
-                if (post.votes > 0 || post.votes < 0) {
+                if (post.votes !== 0) {
                     const cid = cids[index];
                     bulkAdd.push([`cid:${cid}:uid:${post.uid}:pids:votes`, post.votes, post.pid]);
                 }

--- a/test/api.js
+++ b/test/api.js
@@ -331,7 +331,7 @@ describe('API', async () => {
                         return;
                     }
 
-                    const pathParams = (path.match(/{[\w\-_*]+}?/g) || []).map(match => match.slice(1, -1));
+                    const pathParams = (path.match(/{[\w-_*]+}?/g) || []).map(match => match.slice(1, -1));
                     const schemaParams = context[method].parameters.map(param => (param.in === 'path' ? param.name : null)).filter(Boolean);
                     assert(pathParams.every(param => schemaParams.includes(param)), `${method.toUpperCase()} ${path} has path parameters specified but not defined`);
                 });

--- a/test/posts.js
+++ b/test/posts.js
@@ -559,7 +559,7 @@ describe('Post\'s', () => {
         });
 
         it('should error if title is too long', async () => {
-            const longTitle = new Array(meta.config.maximumTitleLength + 2).join('a');
+            const longTitle = (Array.from({ length: meta.config.maximumTitleLength + 2 })).join('a');
             try {
                 await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'edited post content', title: longTitle });
             } catch (err) {
@@ -604,7 +604,7 @@ describe('Post\'s', () => {
         });
 
         it('should error if content is too long', async () => {
-            const longContent = new Array(meta.config.maximumPostLength + 2).join('a');
+            const longContent = (Array.from({ length: meta.config.maximumPostLength + 2 })).join('a');
             try {
                 await apiPosts.edit({ uid: voterUid }, { pid: pid, content: longContent });
             } catch (err) {

--- a/test/user.js
+++ b/test/user.js
@@ -353,7 +353,9 @@ describe('User', () => {
         it('should only post 1 topic out of 10', async () => {
             await User.create({ username: 'flooder', password: '123456' });
             const { jar } = await helpers.loginUser('flooder', '123456');
-            const titles = new Array(10).fill('topic title');
+            let arr = Array.from({ length: 10 });
+            arr.fill('topic title');
+            const titles = arr;
             const res = await Promise.allSettled(titles.map(async (title) => {
                 const { body } = await helpers.request('post', '/api/v3/topics', {
                     form: {
@@ -987,7 +989,9 @@ describe('User', () => {
 
         it('should let updating profile if current username is above max length and it is not being changed', async () => {
             const maxLength = meta.config.maximumUsernameLength + 1;
-            const longName = new Array(maxLength).fill('a').join('');
+            let arr = Array.from({ length: maxLength });
+            arr.fill('a');
+            const longName = arr.join('');
             const uid = await User.create({ username: longName });
             await apiUser.update({ uid: uid }, { uid: uid, username: longName, email: 'verylong@name.com' });
             const userData = await db.getObject(`user:${uid}`);

--- a/test/user.js
+++ b/test/user.js
@@ -353,7 +353,7 @@ describe('User', () => {
         it('should only post 1 topic out of 10', async () => {
             await User.create({ username: 'flooder', password: '123456' });
             const { jar } = await helpers.loginUser('flooder', '123456');
-            let arr = Array.from({ length: 10 });
+            const arr = Array.from({ length: 10 });
             arr.fill('topic title');
             const titles = arr;
             const res = await Promise.allSettled(titles.map(async (title) => {
@@ -989,7 +989,7 @@ describe('User', () => {
 
         it('should let updating profile if current username is above max length and it is not being changed', async () => {
             const maxLength = meta.config.maximumUsernameLength + 1;
-            let arr = Array.from({ length: maxLength });
+            const arr = Array.from({ length: maxLength });
             arr.fill('a');
             const longName = arr.join('');
             const uid = await User.create({ username: longName });


### PR DESCRIPTION
`oxlint` is a fast, Rust-based, multi-threaded linter. Because it runs so fast, the idea is that you can put it before the usual `ESLint` step to get much faster feedback. See new entry in `install/package.json`.

[Oxlint output](https://github.com/CMU-313/spring24-nodebb-roger/files/14579150/oxlint_output.txt) run on our unmodified repo.

Additional screenshot:
![oxlint_screenshot](https://github.com/CMU-313/spring24-nodebb-roger/assets/92952795/92fcdb63-5c5f-4e08-8b2a-90521ca48a06)


Note that `oxlint` finished in just 39ms:
```
Finished in 39ms on 784 files with 87 rules using 16 threads.
Found 27 warnings and 0 errors.
```

While `ESLint` (cold start, cache deleted) takes a full 15 seconds:
```
kroening@geruestwerk:~/CMU/17313/projects/spring24-nodebb-roger$ time npm run lint

> nodebb@2.8.1 lint
> npx tsc && eslint --cache ./nodebb .


real    0m15.446s
user    0m29.542s
sys     0m1.320s
```
The savings on CI might be larger, because a Docker container is likely to be more resource constrained than my local setup.

`npm run lint` reports no errors for the same codebase.  I think this is because `oxlint` is bundled with [additional rules](https://github.com/sindresorhus/eslint-plugin-unicorn)?